### PR TITLE
Use dark style on buttons

### DIFF
--- a/Master.css
+++ b/Master.css
@@ -40,9 +40,15 @@ You can Contact me on discord if you have any issues or questions : Trigstur#591
 }
 .UIButton--inverted, .UIButton--inverted:visited {
     box-shadow: inset 0 0 0 3px #ffffff;
-    }
+}
 .UIButton-wrapper {    
-     color: black;
+     color: #DADEE0;
+}
+.UIButton--whiteBorder {
+    background: #1F2121 !important;
+}
+.UIButton--whiteBorder:hover {
+    background: #363d40 !important;
 }
 .ModeControls, .ModeControls-actions {
     background: #363d40 !important;
@@ -582,7 +588,7 @@ html, body {
 }
 .SiteHeader-logo:after {
     box-sizing: border-box;
-    content: "Trigstur's Quizlet | DarkSkin | v0.2.1" !important;
+    content: "Trigstur's Quizlet | DarkSkin | v0.2.2" !important;
     background-color: rgb(35, 35, 35);
     border-radius: 4px;
     padding: 5px;


### PR DESCRIPTION
In the original style, all buttons are consistent color, like this:
![0](https://user-images.githubusercontent.com/4084885/39683317-7c6c6fae-51bd-11e8-8dbd-36bd73cc35f9.PNG)

Previously in code Options was (1) (by my opinion) mismatched to the other buttons (Flashcards mode) and (2) (by my opinion) causing fatigue in learning sessions (Flashcards mode, Write mode).

![3](https://user-images.githubusercontent.com/4084885/39683348-a65b52b2-51bd-11e8-964b-64d22eae0276.PNG)

This is the proposed version:

![2](https://user-images.githubusercontent.com/4084885/39683390-d99eb1f0-51bd-11e8-8370-15ac05a929e5.PNG)

---

Also, the UI buttons look nicer too, in my opinion:

Original unstyled:
![111111111](https://user-images.githubusercontent.com/4084885/39683488-8ec3ffe0-51be-11e8-9532-04f147b1025a.PNG)

Original styled:
![22222](https://user-images.githubusercontent.com/4084885/39683491-942a895e-51be-11e8-8e29-0399f7bca212.PNG)

Proposal:
![33333](https://user-images.githubusercontent.com/4084885/39683495-95d9f938-51be-11e8-8b05-daf70798d226.PNG)

----

Note, color change on "Options" hover is a little different to buttons (I tried equalizing it, but couldn't manage it - maybe an easier solution would be that other buttons should be changed to not invert completely, but just to have a little brighter background, just like the Options button).